### PR TITLE
Remove duplicate CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Default owners for items not matched below
-
-* @klizhentas @russjones @r0mant


### PR DESCRIPTION
Quick clean-up commit so the only CODEOWNERS file is the one we created.